### PR TITLE
Add recurai.com to an email bots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
   - [AI Assistants](#ai-assistants)
   - [Desktop Apps](#desktop-apps)
   - [Twitter Bots](#twitter-bots)
+  - [Email Bots](#email-bots)
 - [Thanks to all the contributors!](#thanks-to-all-the-contributors)
 
 
@@ -194,6 +195,8 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 ## Twitter Bots
 - [chatgpt-twitter-bot](https://github.com/transitive-bullshit/chatgpt-twitter-bot): Twitter bot powered by OpenAI's ChatGPT. 
 
+## Email Bots
+- [recurai-email-bot](https://recurai.com/): Email bot powered by OpenAI's ChatGPT.
 
 # Thanks to all the contributors!
 <a href="https://github.com/eon01/awesome-chatgpt/graphs/contributors">


### PR DESCRIPTION
Hi there,

I've added a new "email bot" section for my chatgpt-over-email service [recurai.com](https://recurai.com/). Its in beta, but there are big plans in the works.

Thanks a lot for this list!