### PR TITLE
docs: Add gpt-commit tool under Emacs section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If you would like to sponsor this project, please contact me at aymen at faun do
     - [WeChat](#wechat)
     - [LINE](#line)
     - [Prompts](#prompts)
+    - [Emacs](#emacs)
   - [Embeddings/Vector Databases](#embeddingsvector-databases)
   - [Plugins Store](#plugins-store)
   - [AI Assistants](#ai-assistants)

--- a/README.md
+++ b/README.md
@@ -361,10 +361,6 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 
 - [awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts): A curated list of ChatGPT prompts
 
-### Emacs
-
-- [gpt-commit](https://github.com/ywkim/gpt-commit): An Emacs package that uses OpenAI's GPT model to automatically generate commit messages, aiming to save developers' time and increase efficiency.
-
 ### DuckDuckGo
 
 - [DuckDuckGPT](https://www.duckduckgpt.com) 🐤 Adds the magic of ChatGPT to DuckDuckGo sidebar (powered by GPT-4!)
@@ -372,6 +368,10 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 ### Brave Search
 
 - [BraveGPT](https://www.bravegpt.com) 🦁 Adds the magic of ChatGPT to Brave Search sidebar (powered by GPT-4!)
+
+### Emacs
+
+- [gpt-commit](https://github.com/ywkim/gpt-commit): An Emacs package that uses OpenAI's GPT model to automatically generate commit messages, aiming to save developers' time and increase efficiency.
 
 ## Embeddings/Vector Databases
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 
 - [awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts): A curated list of ChatGPT prompts
 
+### Emacs
+
+- [gpt-commit](https://github.com/ywkim/gpt-commit): Generate conventional commit messages using GPT in Emacs
+
 ### DuckDuckGo
 
 - [DuckDuckGPT](https://www.duckduckgpt.com) 🐤 Adds the magic of ChatGPT to DuckDuckGo sidebar (powered by GPT-4!)

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 
 ### Emacs
 
-- [gpt-commit](https://github.com/ywkim/gpt-commit): Generate conventional commit messages using GPT in Emacs
+- [gpt-commit](https://github.com/ywkim/gpt-commit): An Emacs package that uses OpenAI's GPT model to automatically generate commit messages, aiming to save developers' time and increase efficiency.
 
 ### DuckDuckGo
 


### PR DESCRIPTION
## Description

This PR adds a new tool, GPT-Commit, to the list.

[GPT-Commit](https://github.com/ywkim/gpt-commit) - An Emacs package that uses OpenAI's GPT model to automatically generate commit messages, aiming to save developers' time and increase efficiency.

GPT-Commit takes advantage of the GPT model from OpenAI to generate conventionally-styled commit messages. It could save developer's time and increase efficiency by reducing the time spent on writing commit messages.