### PR TITLE
Adding EmbedchainJS framework to JavaScript Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - 🇨🇳 [wechat-bot](https://github.com/wangrongding/wechat-bot): a WeChat bot based on OpenAi ChatGPT + WeChaty that can be used to help you automatically reply to WeChat messages, or manage WeChat groups/friends, detect zombie fans, etc...
 - [chatgpt.js](https://chatgpt.js.org) 🤖 A powerful client-side JavaScript library for ChatGPT
 - [gpt-json](https://github.com/KLaci/gpt-json): Node.js library to get structured responses from OpenAI's APIs
+- [Embedchain-JS](https://github.com/embedchain/embedchainjs): Framework to create ChatGPT like bots over your dataset.
 
 ### Golang
 


### PR DESCRIPTION
Adding Embedchain (JS version) framework to the list.

Helps create ChatGPT like bots, easily and over your own dataset.
Repo: https://github.com/embedchain/embedchainjs