### PR TITLE
Add Locally Uncensored to Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [ChatGPT for Mac](https://github.com/vincelwt/chatgpt-mac): ChatGPT for Mac, living in your menubar.
 - [ChatGPT Desktop Application (Mac, Windows and Linux)](https://github.com/lencx/ChatGPT): ChatGPT Desktop Application (Mac, Windows and Linux)
 - [ChatGPT](https://github.com/HemulGM/ChatGPT): ChatGPT Desktop Application (Windows, Mac, iOS, Android and Linux)
+- [Locally Uncensored](https://github.com/PurpleDoubleD/locally-uncensored): All-in-one local AI desktop app for uncensored chat, image generation, and video creation. Powered by Ollama & ComfyUI. Runs 100% offline.
 
 ## Twitter Bots
 


### PR DESCRIPTION
Hi! I'd like to add **[Locally Uncensored](https://github.com/PurpleDoubleD/locally-uncensored)** to the Desktop Apps section.

**What it is:** An all-in-one local AI desktop app for uncensored chat, image generation, and video creation. Powered by Ollama & ComfyUI. Runs 100% offline.

**Why it fits:** It's a desktop application (built with Tauri) that provides ChatGPT-like functionality locally, fitting naturally in the Desktop Apps section alongside other desktop chat clients.

Thank you for maintaining this awesome list!