### PR TITLE
Add Not Human Search and AI Dev Jobs to Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - Open source replicate of ChatGPT Plus products including Code Interpreter, Plugins and Web Browsing
 - [OpenAssistantGPT](https://github.com/marcolivierbouch/OpenAssistantGPT): An open source platform to build chatbot over the OpenAI Assistant API
 - [Taskade](https://taskade.com): AI-native workspace platform with multi-model support (GPT-4o, Claude, Gemini) for building apps, deploying AI agents, and automating workflows.
+- [Not Human Search](https://nothumansearch.ai/): AI tool discovery engine with agentic scoring. Search 8,600+ AI tools and MCP servers via REST API and MCP server.
+- [AI Dev Jobs](https://aidevboard.com/): AI/ML-focused job board with REST API and MCP server for programmatic access to 5,600+ AI/ML jobs.
 
 ## Desktop Apps
 


### PR DESCRIPTION
Adds two AI-powered web applications to the Web Apps section:

- **[Not Human Search](https://nothumansearch.ai/)** — AI tool discovery engine with agentic scoring. Indexes 8,600+ AI tools and MCP servers with REST API and MCP server for programmatic access.
- **[AI Dev Jobs](https://aidevboard.com/)** — AI/ML-focused job board aggregating 5,600+ jobs from 300+ companies. REST API and MCP server for programmatic job search.

Both are free to use and provide developer-friendly APIs.