### PR TITLE
Add Voidly Censorship Action (GPT Action spec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 ## Plugins Store
 
 - [getit.ai](https://www.getit.ai/gpt-plugins): open plugin store for easy plugin installs.
+- [Voidly Censorship Action](https://github.com/voidly-ai/chatgpt-action): open-source GPT Action (openapi.yaml) that gives custom GPTs real-time access to internet censorship data across 126+ countries and 5,700+ citable incidents. Free API (CC BY 4.0).
 
 ## AI Assistants
 


### PR DESCRIPTION
## Summary

Adds the [Voidly Censorship Action](https://github.com/voidly-ai/chatgpt-action) to the **Plugins Store** section.

## What it is

An open-source OpenAI GPT Action spec (`openapi.yaml`) that gives custom GPTs real-time access to internet censorship data. Users import the openapi.yaml into GPT Builder to instantly give their GPT the ability to:

- Query live censorship status across **126+ countries**
- Pull from **5,700+ citable incidents** (OONI, CensoredPlanet, IODA)
- Check whether a specific domain is blocked in a given country
- Fetch platform/ISP risk scores and 7-day shutdown forecasts

## Checklist

- [x] Open source (CC BY 4.0 / MIT)
- [x] Free to use (no auth required for public data endpoints)
- [x] Relevant to the list (it's a ChatGPT/GPT integration built on OpenAI's GPT Actions standard)
- [x] Not a duplicate