### PR TITLE
Add AI Model Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 ### Golang
 
 - [OpenAI API - ChatGPT, GPT-3, GPT-4, DALL·E, Whisper (unofficial)](https://github.com/sashabaranov/go-openai)
+- [AI Model Gateway](https://github.com/SSC-STUDIO/Ai-Model-Gateway): Self-hosted Go LLM operations gateway for OpenAI-compatible and Anthropic-compatible routing, fallback, telemetry, benchmarking, config publishing, updates, and rollback.
 - [aiac](https://github.com/gofireflyio/aiac): Artificial Intelligence Infrastructure-as-Code Generator.
 - [openaigo](https://github.com/otiai10/openaigo): OpenAI (ChatGPT) API Client for Go
 - [whatsapp-gpt](https://github.com/danielgross/whatsapp-gpt): WhatsApp bot that uses Golang with a multichat option (chatgpt chatting with chatgpt).


### PR DESCRIPTION
Adds [AI Model Gateway](https://github.com/SSC-STUDIO/Ai-Model-Gateway) to the Golang section under Developer Libraries, SDKs, and APIs.

Why it fits:
- It is open-source and free to self-host.
- It is implemented in Go and provides OpenAI-compatible and Anthropic-compatible API gateway workflows for ChatGPT/GPT-style developer integrations.
- The list already includes adjacent developer API/gateway tooling such as GPTRouter.

Disclosure: I maintain AI Model Gateway, so this is a self-submission. I kept the entry to one factual README line.