### PR TITLE
Add CreatorSkills to Plugins Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 ## Plugins Store
 
 - [getit.ai](https://www.getit.ai/gpt-plugins): open plugin store for easy plugin installs.
+- [CreatorSkills](https://creatorskills.co): Marketplace of 30+ AI skills (SKILL.md format) for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Compatible with Claude, ChatGPT, and 20+ AI platforms.
 
 ## AI Assistants
 


### PR DESCRIPTION
Adds [CreatorSkills](https://creatorskills.co) — a marketplace of 30+ AI skills (SKILL.md format) for content creators — to the Plugins Store section.

CreatorSkills is a curated marketplace of downloadable AI skills for YouTube creators, including scripts, sponsorship analysis, content repurposing, and audience growth tools. Skills are compatible with Claude, ChatGPT, and 20+ AI platforms via the open SKILL.md format.