### PR TITLE
Add Superhighway OpenAI function calling web search guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [ChatGPT Python Applications](https://github.com/xiaowuc2/ChatGPT-Python-Applications) : Tutorials of ChatGPT using Python(with video) with third-party extensions, integrations with other tools, ports for different platforms, etc.
 - [LLM Introduction: Learn Language Models](https://gist.github.com/rain-1/eebd5e5eb2784feecf450324e3341c8d) : A curated list of useful focused intro resources for learning about LLMs.
 - [Connect ChatGPT to the Internet](https://github.com/mahseema/connect-chatgpt-to-internet): A complete tutorial to help connect free version of ChatGPT to the internet
+- [Superhighway + OpenAI Function Calling Guide](https://superhighway.walls.sh/guides/web-search-openai-function-calling): Add live web search to any OpenAI app using the chat.completions tools parameter, powered by the Superhighway web search API (free key or x402 USDC pay-per-call).
 
 # Stuff
 


### PR DESCRIPTION
Adds a guide to the **Documentations, Tutorials & Other Resources** section.

[Superhighway + OpenAI Function Calling Guide](https://superhighway.walls.sh/guides/web-search-openai-function-calling) shows how to add live web search to any OpenAI app using the `chat.completions` tools parameter, fitting right alongside the existing "Connect ChatGPT to the Internet" entry.

Superhighway is a web search API for AI agents (search, news, images, scrape, research). Free API key (1k/month) or x402 USDC pay-per-call. MCP server: `npx -y superhighway-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)