### PR TITLE
docs: add AI Router examples repo resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [ChatGPT Python Applications](https://github.com/xiaowuc2/ChatGPT-Python-Applications) : Tutorials of ChatGPT using Python(with video) with third-party extensions, integrations with other tools, ports for different platforms, etc.
 - [LLM Introduction: Learn Language Models](https://gist.github.com/rain-1/eebd5e5eb2784feecf450324e3341c8d) : A curated list of useful focused intro resources for learning about LLMs.
 - [Connect ChatGPT to the Internet](https://github.com/mahseema/connect-chatgpt-to-internet): A complete tutorial to help connect free version of ChatGPT to the internet
+- [AI Router OpenAI-Compatible Examples](https://github.com/airouter-dev/ai-router-openai-compatible-examples): Open-source setup examples for OpenAI-compatible clients, including cURL, Python, Node.js, Cursor, Continue, LiteLLM, and Open WebUI.
 
 # Stuff
 


### PR DESCRIPTION
Adds the open-source `ai-router-openai-compatible-examples` repository under Documentations, Tutorials & Other Resources.

Why it fits:
- free and open-source GitHub resource
- focused on OpenAI-compatible client setup examples
- useful for developers working with ChatGPT-style APIs

This PR intentionally adds the examples repo as a resource, not the commercial service itself.