### PR TITLE
Add Iqraa Library OpenAI Academy tutorial series

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [ChatGPT Python Applications](https://github.com/xiaowuc2/ChatGPT-Python-Applications) : Tutorials of ChatGPT using Python(with video) with third-party extensions, integrations with other tools, ports for different platforms, etc.
 - [LLM Introduction: Learn Language Models](https://gist.github.com/rain-1/eebd5e5eb2784feecf450324e3341c8d) : A curated list of useful focused intro resources for learning about LLMs.
 - [Connect ChatGPT to the Internet](https://github.com/mahseema/connect-chatgpt-to-internet): A complete tutorial to help connect free version of ChatGPT to the internet
+- [Iqraa Library — OpenAI Academy](https://iqraa.tech/category/ai-genai/openai/): A free, structured tutorial series on the OpenAI API and Academy, with practical guides and real request/response examples rather than reference-only docs.
 
 # Stuff
 


### PR DESCRIPTION
Adds a free, structured tutorial series on the OpenAI API and Academy to the Documentations, Tutorials & Other Resources section. Practical guides with real request/response examples rather than reference-only docs.

Link: https://iqraa.tech/category/ai-genai/openai/