### PR TITLE
Add AI Buddy to Chrome extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [ChatGPT Widescreen Mode](https://chatgptwidescreen.com) 🖥️ Add Widescreen + Fullscreen modes to ChatGPT for enhanced viewing
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
 - [Meeper](https://github.com/pas1ko/meeper) - Transcriptions, summary and more using ChatGPT and Whisper for meetings and any browser tab.
+- [AI Buddy](https://github.com/mnbqwe10/ai_buddy): Open-source Chrome side panel that sends selected text or annotated screenshots to ChatGPT, Claude, Gemini, DeepSeek, Copilot, WhatsApp, Telegram, or Discord. 10 starter scenarios (Explain, Translate, Summarize, Debug Code, etc.). No backend, your accounts only.
 
 ### Firefox
 


### PR DESCRIPTION
Adds AI Buddy to the **Browser Extensions > Chrome** section.

AI Buddy is an open-source Chrome side panel that sends selected text or annotated screenshots to ChatGPT, Claude, Gemini, DeepSeek, Copilot, WhatsApp, Telegram, or Discord.

## What it does

- Highlight any text on a page → send it to your chosen AI platform with one click (no copy-paste, no tab switching)
- Capture + annotate a screenshot (crop / highlight / blur / draw arrows / labels) → send to AI for visual review
- 10 starter scenarios: Explain, Translate, Summarize, Draft Reply, Polish, Brainstorm, Debug Code, Write Tests, etc.

## Why this list

Same category as the other Chrome extensions in this section (side-panel / selection-based / multi-platform AI wrappers). Differentiation:

- **No backend / no own model** — uses your existing accounts (no subscription, no data through third party)
- **Multi-platform**: 6 AI chat + 3 messaging apps
- **Per-platform send behavior**: AI platforms auto-submit, messaging apps draft-only

## Links

- Chrome Web Store: https://chromewebstore.google.com/detail/ai-buddy/eigpaeoigklelmfgnkljhbjjbpohenpn
- GitHub: https://github.com/mnbqwe10/ai_buddy (MIT)