### PR TITLE
Add Markstream streaming Markdown UI library

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - 🇨🇳 [ChatGPT-wechat-bot](https://github.com/AutumnWhj/ChatGPT-wechat-bot): ChatGPT for wechat
 - [AI Legion](https://github.com/eumemic/ai-legion): An LLM-powered autonomous agent platform
 - [Horizon AI Template](https://github.com/horizon-ui/chatgpt-ai-template): Trendiest Open-Source ChatGPT AI Template & Starter Kit for React & NextJS
+- [Markstream](https://github.com/Simon-He95/markstream-vue): Streaming Markdown UI library for AI chat applications, with packages for Vue, React, Svelte, and Angular.
 
 ### Kotlin
 


### PR DESCRIPTION
Adds Markstream under TypeScript developer libraries.

Markstream is an MIT-licensed streaming Markdown UI library for AI chat applications. It handles partial LLM output and supports packages for Vue/Nuxt, React/Next.js, Svelte/SvelteKit, and Angular.

GitHub: https://github.com/Simon-He95/markstream-vue
Docs: https://markstream.simonhe.me/

Disclosure: I maintain Markstream and am happy to adjust wording or placement.