### PR TITLE
Add ChatVault to Web Apps (export ChatGPT/Claude conversations to PDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ A curated list of awesome ChatGPT resources, libraries, SDKs, APIs, and more.
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - Open source replicate of ChatGPT Plus products including Code Interpreter, Plugins and Web Browsing
 - [OpenAssistantGPT](https://github.com/marcolivierbouch/OpenAssistantGPT): An open source platform to build chatbot over the OpenAI Assistant API
 - [Taskade](https://taskade.com): AI-native workspace platform with multi-model support (GPT-4o, Claude, Gemini) for building apps, deploying AI agents, and automating workflows.
+- [ChatVault](https://chat-export-seven.vercel.app/): Export your ChatGPT or Claude conversations to clean, printable PDFs. Free, no signup, runs entirely in your browser so nothing is uploaded. [Source](https://github.com/ImmortalDemonGod/chatvault).
 
 ## Desktop Apps
 


### PR DESCRIPTION
Adds **ChatVault** to the Web Apps section.

ChatVault is a free web app that turns the raw `conversations.json` from a ChatGPT or Claude data export into clean, readable, printable PDFs (titles, roles, full text, code blocks). It runs entirely in the browser, so conversations are never uploaded anywhere, which complements the existing export entries (ChatGPT-pdf, ChatGPT Export) by also handling Claude and producing per-conversation PDFs.

- Live tool: https://chat-export-seven.vercel.app/
- Source (client-side, MIT-spirit): https://github.com/ImmortalDemonGod/chatvault

Single-line addition, alphabetically-agnostic to match the section's existing ordering. Thanks for maintaining the list.